### PR TITLE
Fix XML encoding problem

### DIFF
--- a/src/main/scala/Moedictionary.scala
+++ b/src/main/scala/Moedictionary.scala
@@ -18,7 +18,7 @@ object Moedictionary extends App {
   val db = Database.forURL(url = "jdbc:sqlite:development.unicode.sqlite3", driver = "org.sqlite.JDBC")
 
   import java.io._
-  val out = new PrintWriter("moedict_templates/MoeDictionary.xml")
+  val out = new PrintWriter("moedict_templates/MoeDictionary.xml", "UTF-8")
 
   db withSession {
     


### PR DESCRIPTION
```
% sbt get-db patch-db run build-dict
[skip]
/Users/jsa/Developer/moedict-mac/moedict_templates
""".."/bin"/build_dict.sh"  "萌典" MoeDictionary.xml MoeDictionary.css MyInfo.plist
- Building 萌典.dictionary.
- Cleaning objects directory.
- Preparing dictionary template.
- Preprocessing dictionary sources.
tr: Illegal byte sequence
Error.
make: *** [all] Error 1
echo "Installing into ~/Library/Dictionaries".
Installing into ~/Library/Dictionaries.
mkdir -p ~/Library/Dictionaries
ditto --noextattr --norsrc ./objects/"萌典".dictionary  ~/Library/Dictionaries/"萌典".dictionary
ditto: can't get real path for source
make: *** [install] Error 1
java.lang.RuntimeException: Build Dictionary failed.
    at scala.sys.package$.error(package.scala:27)
```
